### PR TITLE
Replaced isinstance check for spidev with hasattr check for xfer transfer function. The change was made to enable 'virtual SPI terminal' which is a separate python interface to a component that provide virtual SPI terminal. The virtual SPI terminal component may be external and can be accessed via various communication protocols other than SPI. The virtual SPI terminal python interface must expose this 'xfer' function and other functions found in spidev, especially the SPI mode.

### DIFF
--- a/opc/__init__.py
+++ b/opc/__init__.py
@@ -49,9 +49,10 @@ class OPC(object):
         self.model      = kwargs.get('model', 'N2')
 
         # Check to make sure the connection is a valid SpiDev instance
-        assert isinstance(spi_connection, spidev.SpiDev), "The SPI connection must be a valid spidev.SpiDev instance"
+        msg = ("The SPI connection must be a valid SPI master with "
+               "transfer function 'xfer'")
+        assert hasattr(spi_connection, 'xfer'), msg
         assert self.cnxn.mode == 1, "SPI mode must be 1"
-
         # Set the firmware version upon initialization
         try:
             self.firmware['version']    = int(re.findall("\d{3}", self.read_info_string())[-1])


### PR DESCRIPTION
Replacing isinstance check with hasattr check for virtual SPI terminal.