### PR TITLE
TypeError: unorderable types:dict()<int()

### DIFF
--- a/opc/__init__.py
+++ b/opc/__init__.py
@@ -173,7 +173,7 @@ class _OPC(object):
         if len(vals) < 4:
             return None
 
-        if self.firmware < 16:
+        if self.firmware['major'] < 16:
             return ((vals[3] << 24) | (vals[2] << 16) | (vals[1] << 8) | vals[0]) / 12e6
         else:
             return self._calculate_float(vals)


### PR DESCRIPTION
Hi,

I am getting this issue from time to time (I usually get it when I power the sensor for the first time):

<pre>
  File "/home/pi/AQ/Code/classes/OPC.py", line 143, in read
    hist=self.alpha.histogram(number_concentration=False)
  File "/home/pi/.local/lib/python3.5/site-packages/opc/__init__.py", line 545, in histogram
    data['Sampling Period'] = self._calculate_period(resp[44:48])
  File "/home/pi/.local/lib/python3.5/site-packages/opc/__init__.py", line 176, in _calculate_period
    if self.firmware < 16:
TypeError: unorderable types: dict() < int()
</pre>

I think that this change should fix it.